### PR TITLE
fix compilation failures

### DIFF
--- a/go/trivial.go
+++ b/go/trivial.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/uber/jaeger-client-go"
 	"github.com/uber/jaeger-client-go/config"
+
+	"github.com/opentracing/opentracing-go"
 )
 
 func main() {
@@ -25,6 +27,10 @@ func main() {
 		"your_service_name",
 		config.Logger(jaeger.StdLogger),
 	)
+	if (err != nil){
+		fmt.Println("Cannot create tracer: %v\n", err.Error())
+		os.Exit(1)
+	}
 	defer closer.Close()
 
 	// 2) Demonstrate simple OpenTracing instrumentation


### PR DESCRIPTION
Nice to have a trivial example! It makes experimenting super easy. 
This fixes 2 compilation issues: 

```
$ go run ./trivial.go localhost
# command-line-arguments
./trivial.go:5:2: imported and not used: "os"
./trivial.go:34:38: undefined: opentracing
```